### PR TITLE
[3주차] jiixon

### DIFF
--- a/jiixon/src/main/java/BOJ/단지번호붙이기_2667/solution.java
+++ b/jiixon/src/main/java/BOJ/단지번호붙이기_2667/solution.java
@@ -1,0 +1,66 @@
+package main.java.BOJ.단지번호붙이기_2667;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class solution { //메모리:14132KB 시간:140ms
+    public static int[][] graph;
+    public static int n;
+    public static ArrayList<Integer> counts = new ArrayList<>();
+
+
+    public static int dfs(int x, int y){
+        /*graph의 초깃값이 모두 0이기때문에 1인 경우를 방문하지 않았다고 봄
+        * 1을 만나면 방문처리를 함으로 하나의 dfs가 진행될때마다 count++을 진행
+        */
+
+        if(x<=-1 || x>=n || y<=-1 ||y>=n) return 0; //좌표가 공간을 넘어가면 바로 종료
+        if (graph[x][y] == 0) return 0; // 현재 위치가 빈 칸이면 0을 반환
+
+        int count = 1;
+
+        graph[x][y] = 0; //현재위치 방문처리
+
+        count+=dfs(x-1,y);
+        count+=dfs(x,y-1);
+        count+=dfs(x+1,y);
+        count+=dfs(x,y+1);
+
+        return count;
+
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        graph = new int[n][n];
+
+
+        //이차원 배열 입력받고 저장
+        for(int i = 0; i<n; i++){
+            String str = br.readLine();
+            for(int j = 0; j<n; j++){
+                graph[i][j] = str.charAt(j) - '0';
+            }
+        }
+
+        for(int i = 0; i<n; i++){
+            for(int j = 0; j<n; j++){
+                int totalCount = dfs(i,j);
+                if(totalCount>0){ //하나이상의 집을 세었다면
+                    counts.add(totalCount);
+                }
+            }
+        }
+
+        Collections.sort(counts); //오름차순 후 출력
+        System.out.println(counts.size());
+        for(Integer i: counts){
+            System.out.println(i);
+        }
+
+
+    }
+}

--- a/jiixon/src/main/java/BOJ/미로_탐색_2178/solution.java
+++ b/jiixon/src/main/java/BOJ/미로_탐색_2178/solution.java
@@ -1,0 +1,78 @@
+package main.java.BOJ.미로_탐색_2178;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+class Node{
+    int x;
+    int y;
+
+    public Node(int x, int y){
+        this.x = x;
+        this.y = y;
+    }
+
+    public int getX(){
+        return this.x;
+    }
+
+    public int getY(){
+        return this.y;
+    }
+}
+public class solution { //메모리:14724KB 시간:132ms
+    public static int[][] graph;
+    public static int n,m;
+    public static int[] dx = {-1, 1, 0, 0};
+    public static int[] dy = {0, 0, -1, 1};
+    public static int bfs(int x, int y){
+
+        LinkedList<Node> queue = new LinkedList<>();
+        queue.offer(new Node(x, y)); //현재 좌표 queue에 넣음
+
+        while (!queue.isEmpty()){
+            Node current = queue.poll();
+            x = current.getX();
+            y = current.getY();
+
+            for(int i = 0; i<4; i++){
+                //상하좌우에 따른 위치 nx, ny
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if(nx<=-1 || nx>=n || ny<=-1 || ny>=m){ //위치가 범위 밖에 있으면
+                    continue;
+                }
+                if(graph[nx][ny] == 0){ //위치가 갈 수 없는 곳이면
+                    continue;
+                }
+                if(graph[nx][ny] == 1){ //위치가 갈 수 있는 곳이라면
+                    graph[nx][ny] = graph[x][y] + 1; //기존 값에 +1 해서 오른쪽 아래방향으로 이동하면서 count
+                    queue.offer(new Node(nx,ny));
+                }
+            }
+        }
+        return graph[n-1][m-1];
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        graph = new int[n][m];
+
+        //이차원 배열 입력받고 저장
+        for(int i = 0; i<n; i++){
+            String str = br.readLine();
+            for(int j = 0;j<m; j++){
+                graph[i][j] = str.charAt(j) - '0';
+            }
+        }
+
+        System.out.println(bfs(0,0)); //시작점부터최단거리 반환
+
+    }
+}

--- a/jiixon/src/main/java/BOJ/바이러스_2606/solution.java
+++ b/jiixon/src/main/java/BOJ/바이러스_2606/solution.java
@@ -1,0 +1,56 @@
+package main.java.BOJ.바이러스_2606;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+public class solution { //메모리:14104KB 시간:124ms
+    public static boolean visited[];
+    public static int cnt;
+    public static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+    public static void bfs(int start){
+        LinkedList<Integer> queue = new LinkedList<>();
+
+        //현재 노드 방문처리
+        queue.offer(start);
+        visited[start] = true;
+
+        //큐 빌때까지 반복
+        while (!queue.isEmpty()){
+            int x = queue.poll();
+            cnt++;
+            for(int i = 0; i<graph.get(x).size(); i++){
+                int y = graph.get(x).get(i);
+                if(!visited[y]){
+                    queue.offer(y);
+                    visited[y] = true;
+                }
+            }
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+        int c = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        visited = new boolean[t+1];
+
+        //그래프 초기화
+        for(int i =0; i<t+1; i++){
+            graph.add(new ArrayList<>());
+        }
+
+        //입력값 인접 노드 데이터 저장
+        for(int i = 0; i<c; i++){
+            st = new StringTokenizer(br.readLine());
+            graph.get(Integer.parseInt(st.nextToken())).add(Integer.parseInt(st.nextToken()));
+        }
+
+        bfs(1);
+        System.out.println(cnt);
+
+    }
+}

--- a/jiixon/src/main/java/BOJ/순열_사이클_10451/solution.java
+++ b/jiixon/src/main/java/BOJ/순열_사이클_10451/solution.java
@@ -1,0 +1,44 @@
+package main.java.BOJ.순열_사이클_10451;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class solution { //메모리:52956KB 시간:588ms
+    public static boolean visited[];
+    public static int[] array;
+
+    public static void dfs(int x){
+        if(visited[x-1]) return;
+
+        visited[x-1] = true;
+        dfs(array[x-1]);
+
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int t = Integer.parseInt(br.readLine());
+        int result[] = new int[t];
+        for(int i = 0; i<t; i++){
+            int size = Integer.parseInt(br.readLine());
+
+            array = new int[size+1];
+            visited = new boolean[size+1];
+
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j<size; j++){
+                array[j] = Integer.parseInt(st.nextToken());
+            }
+
+            for(int j = 1; j<size; j++){
+                if(!visited[j-1]) {
+                    dfs(j);
+                    result[i]++;
+                }
+            }
+        }
+        for(int i : result) System.out.println(i);
+    }
+}


### PR DESCRIPTION
# 10451 순열 사이클
## 문제 설명
     순열을 그래프로 나타내고, 그래프에서 순열 사이클의 개수를 찾는 문제이다.
     1부터 N까지의 정수 N개로 이루어진 순열에서 각 요소를 정점으로 생각하고, 각 요소의 위치를 간선으로 연결하여 
     만든 사이클의 개수를 찾는 문제이다.

<br>

## 논리적 흐름
    DFS는 한 정점에서 시작하여 그래프를 깊이 우선으로 탐색하기 때문에 사이클을 찾는 데 유용하다고 생각했어 선택하게 되었다. 
    인덱스 값은 0부터이지만 문제에서는 1로 시작하기때문에 x-1를 확인하면서 visited 배열을 사용하여 
    방문 노드를 확인하며 DFS 함수를 재귀적으로 호출한다.

<br>

## 성능
    메모리:52956KB  시간:588ms

<br>

# 2606 바이러스
## 문제 설명
    컴퓨터의 개수를 입력받고, 연결되어있는 두 컴퓨터 번호를 입력 받았을 때
    주어진 네트워크에서 1번 컴퓨터에서 웜 바이러스가 퍼지게 되는 컴퓨터의 수를 구하는문제이다.
    

<br>

## 논리적 흐름
    1번 컴퓨터에서 시작하여 웜 바이러스가 퍼지는 것을 탐색해야하기에 
    네트워크에서 한 정점(컴퓨터)에서 다른 정점으로 최단 경로를 찾는 문제와 유사하다고 판단하여 BFS를 선택하게 되었다.
    시작점으로부터 연결된 모든 컴퓨터를 방문하며, 이를 통해 웜 바이러스가 퍼지는 모든 영역을 찾아 방문한 컴퓨터 수를 센다.

<br>

## 성능
    메모리:14104KB 시간:124ms

<br>

# 2667 단지 번호 붙이기
## 문제 설명
    정사각형 모양의 지도에서 연결된 집의 모임인 단지를 찾고, 각 단지에 속하는 집의 수를 오름차순으로 정렬하여 출력하는 문제
    각 집은 1로 표시되어 있고, 연결된 집은 좌우 또는 상하 방향으로 인접해 있는 것을 하나의 단지로 간주한다.
    
<br>

## 논리적 흐름
    이 문제에서는 한 집에서 시작하여 그 집과 연결된 집들을 최대한 깊게 탐색하면서 단지를 형성해야하기에 DFS를 선택하였다.
    DFS 재귀를 호출하면서 count를 하며 해당 집의 개수를 세도록 한다.

<br>

## 성능
    메모리:14132KB  시간:140ms

<br>

# 2178 미로 탐색
## 문제 설명
    이 문제는 주어진 미로에서 출발 지점 (1, 1)에서 도착 지점 (N, M)으로 이동할 때 지나야 하는 최소의 칸 수를 구하는 문제이다. 
    이때 각 칸은 1 또는 0으로 표시되어 있으며, 1은 이동할 수 있는 칸을 나타내고, 0은 이동할 수 없는 칸이다. 
    
<br>

## 논리적 흐름
    최단거리 문제이기에 BFS를 선택하였다. 좌표에서 상하좌우에 해당하여 시점을 재정의하여 그 시점이 갈수있는 방향인지 확인하며
    (범위 밖이거나 0이여서 갈수 없는 곳인지 확인) 갈수 있다면 +1을 계속하여 최종적으로 거리를 구하도록 하였다. 

<br>

## 성능
    메모리:14724KB 시간:132ms
