### PR TITLE
[4주차]

### DIFF
--- a/koungq/src/main/java/BOJ/N_Queen_9663/solution.java
+++ b/koungq/src/main/java/BOJ/N_Queen_9663/solution.java
@@ -1,0 +1,49 @@
+package main.java.BOJ.N_Queen_9663;
+
+import java.util.Scanner;
+
+public class solution {
+
+    private static int[] prev;
+    private static int cnt, n;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        n = sc.nextInt();
+
+        for(int i = 0; i < n; i++) {
+            prev = new int[n];
+            dfs(0, i);
+        }
+
+        System.out.println(cnt);
+    }
+
+    static void dfs(int y, int x) {
+        if(y == n - 1) {
+            cnt++;
+            return;
+        }
+
+        prev[y] = x;
+
+        for(int j = 0; j < n; j++) {
+            boolean isOK = true;
+            for (int i = 0; i < y + 1; i++) {
+                if(j == prev[i])
+                    isOK = false;
+                if(j == prev[i] - (y + 1 - i))
+                    isOK = false;
+                if(j == prev[i] + (y + 1 - i))
+                    isOK = false;
+            }
+
+            if(isOK) {
+                prev[y + 1] = j;
+                dfs(y + 1, j);
+            }
+
+        }
+    }
+}

--- a/koungq/src/main/java/BOJ/N과M_15649/solution.java
+++ b/koungq/src/main/java/BOJ/N과M_15649/solution.java
@@ -1,0 +1,45 @@
+package main.java.BOJ.N과M_15649;
+
+import java.util.Scanner;
+
+public class solution {
+
+    private static boolean[] visited;
+    private static int[] output;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int n = sc.nextInt();
+        int m = sc.nextInt();
+
+        visited = new boolean[n];
+        output = new int[n];
+
+        permutation(0, n, m);
+    }
+
+    static void permutation(int depth, int n, int r) {
+        if (depth == r) {
+            print(output, r);
+            return;
+        }
+
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                output[depth] = i + 1;
+                permutation(depth + 1, n, r);
+                visited[i] = false;
+            }
+        }
+    }
+
+    static void print(int[] arr, int r) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < r; i++)
+            sb.append(arr[i]).append(" ");
+        System.out.println(sb);
+    }
+}

--- a/koungq/src/main/java/BOJ/체스판_다시_칠하기_1018/solution.java
+++ b/koungq/src/main/java/BOJ/체스판_다시_칠하기_1018/solution.java
@@ -1,0 +1,89 @@
+package main.java.BOJ.체스판_다시_칠하기_1018;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class solution {
+
+    private static int n, m;
+    private static boolean[][] board;
+    private static boolean[][] version1 = {
+            {true, false, true, false, true, false, true, false},   // 흰 블럭 시작
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+    };
+    private static boolean[][] version2 = {
+            {false, true, false, true, false, true, false, true},   // 검은 블럭 시작
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+            {false, true, false, true, false, true, false, true},
+            {true, false, true, false, true, false, true, false},
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());   // 체스판 높이 입력 받기
+        m = Integer.parseInt(st.nextToken());   // 체스판 너비 입력 받기
+
+        board = new boolean[n][m];  // B = false, W = true
+
+        // 너비나 높이 중 하나라도 0이라면 입력 받는 값 없이 바로 0 출력 후 리턴
+        if(n == 0 || m == 0) {
+            System.out.println(0);
+            return;
+        }
+
+        // 입력 받기
+        for(int i = 0; i < n; i++) {
+            String line = br.readLine();
+
+            for (int j = 0; j < m; j++) {
+                board[i][j] = line.charAt(j) == 'W';
+            }
+        }
+
+        int min = 9999; // 임시 값
+        for(int i = 0; i + 8 <= n; i++) {
+            for(int j = 0; j + 8 <= m; j++) {
+
+                int cnt = 0;
+                for(int k = i; k < 8 + i; k++) {        // version1 과 비교
+                    for(int l = j; l < 8 + j; l++) {
+                        if(board[k][l] != version1[k - i][l - j])
+                            cnt++;
+                    }
+                }
+
+                if(min > cnt) {
+                    min = cnt;
+                }
+
+                cnt = 0;
+                for(int k = i; k < 8 + i; k++) {        // version2 와 비교
+                    for(int l = j; l < 8 + j; l++) {
+                        if(board[k][l] != version2[k - i][l - j])
+                            cnt++;
+                    }
+                }
+
+                if(min > cnt) {
+                    min = cnt;
+                }
+            }
+        }
+
+        System.out.println(min);
+    }
+}


### PR DESCRIPTION
# 9663 N-Queen
## 문제 설명
    N*N 크기의 체스판에 N개의 퀸을 서로 공격하지 못하게 두는 경우의 수를 구하는 문제 

<br>

## 논리적 흐름
    처음에 체스판의 크기만큼 2차원 배열로 선언하려고 했지만 메모리 초과가 발생했다.
    그래서 열마다 하나의 퀸만 들어갈 수 있다는 특징을 생각했고,
    N 크기의 1차원 배열을 선언하여 배열의 인덱스는 x좌표, 배열의 값은 y좌표로 생각하여 문제를 해결했다.
    그리고 적절한 y좌표를 찾기 위해서 기울기가 1과 -1인 경우를 가장 많이 고민했는데,
    현재 찾으려는 열의 앞의 열들을 탐색하여 '찾으려는 열의 x좌표 - 탐색하고 있는 열의 x좌표' 값 만큼
    탐색하고 있는 열의 y좌표에 더하고 빼며 대각선의 위치를 판별할 수 있었다.
    하나씩 탐색하며 visited배열에 boolean으로 적절한 위치엔 true, 그렇지 않은 위치엔 false를 두어
    true인 부분만 dfs를 진행했다.
    

<br>


## 성능
    메모리: 18096KB, 시간: 11404ms
