### PR TITLE
[5주차]

### DIFF
--- a/koungq/src/main/java/BOJ/계단_오르기_2579/solution.java
+++ b/koungq/src/main/java/BOJ/계단_오르기_2579/solution.java
@@ -1,0 +1,31 @@
+package main.java.BOJ.계단_오르기_2579;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class solution {
+
+    private static int[] stairs = new int[304];
+    private static int[] dp = new int[304];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int cnt = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < cnt; i++) {
+            stairs[i] = Integer.parseInt(br.readLine());
+        }
+
+        dp[0] = stairs[0];
+        dp[1] = Math.max(stairs[0] + stairs[1], stairs[1]);
+        dp[2] = Math.max(stairs[0] + stairs[2], stairs[1] + stairs[2]);
+
+        for (int i = 3; i < cnt; i++) {
+            dp[i] = Math.max(dp[i - 2] + stairs[i], stairs[i - 1] + stairs[i] + dp[i - 3]);
+        }
+
+        System.out.println(dp[cnt - 1]);
+    }
+}

--- a/koungq/src/main/java/BOJ/동전_2293/solution.java
+++ b/koungq/src/main/java/BOJ/동전_2293/solution.java
@@ -1,0 +1,26 @@
+package main.java.BOJ.동전_2293;
+
+import java.util.Scanner;
+
+public class solution {
+
+    static int[] dp = new int[10004];
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int n = sc.nextInt();
+        int k = sc.nextInt();
+
+        dp[0] = 1;
+        for(int i = 0; i < n; i++) {
+            int temp = sc.nextInt();
+
+            for(int j = temp; j <= k; j++) {
+                dp[j] += dp[j - temp];
+            }
+        }
+
+        System.out.println(dp[k]);
+    }
+}

--- a/koungq/src/main/java/BOJ/스티커_9465/solution.java
+++ b/koungq/src/main/java/BOJ/스티커_9465/solution.java
@@ -1,0 +1,50 @@
+package main.java.BOJ.스티커_9465;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class solution {
+
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int t = Integer.parseInt(br.readLine());
+
+        for(int i = 0; i < t; i++) {
+            int n = Integer.parseInt(br.readLine());
+            dp = new int[2][n];
+            int[][] sticker = new int[2][n];
+
+            StringTokenizer st1 = new StringTokenizer(br.readLine());
+            StringTokenizer st2 = new StringTokenizer(br.readLine());
+            for(int j = 0; j < n; j++) {
+                sticker[0][j] = Integer.parseInt(st1.nextToken());
+                sticker[1][j] = Integer.parseInt(st2.nextToken());
+            }
+
+            dp[0][0] = sticker[0][0];
+            dp[1][0] = sticker[1][0];
+            int max = Math.max(dp[0][0], dp[1][0]);
+
+            for(int j = 1; j < n; j++) {
+                if(j == 1) {
+                    dp[0][j] = dp[1][0] + sticker[0][1];
+                    dp[1][j] = dp[0][0] + sticker[1][1];
+                    max = Math.max(dp[0][j], dp[1][j]);
+                    continue;
+                }
+
+                dp[0][j] = Math.max(dp[1][j - 1], dp[1][j - 2]) + sticker[0][j];
+                dp[1][j] = Math.max(dp[0][j - 1], dp[0][j - 2]) + sticker[1][j];
+                max = Math.max(max, Math.max(dp[0][j], dp[1][j]));
+            }
+            sb.append(max).append("\n");
+        }
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# 2579 계단 오르기
## 문제 설명
    계단을 한칸 혹은 두칸을 한 번에 오를 수 있는데 세번 연속 한 칸 오르는건 불가능하다.
    계단마다 주어진 가중치가 있는데, 밟은 계단의 가중치의 합 중 가장 큰 값을 구하라.

<br>

## 논리적 흐름
    시간이 많이 주어지지 않은 상황에서 완전 탐색을 하다간 시간초과가 날 것이므로 이전 결과 값을 토대로 연산하는
    DP를 생각했다. 이전 연산의 합 중 최대값을 계산하여 계단마다 도달하는데 밟는 가중치 합의 최대값을 구했다.

<br>


## 성능
    메모리: 14092KB, 시간: 120ms

<br>


# 9465 스티커
## 문제 설명
    스티커를 떼면 변을 공유하는 스티커가 모두 떨어진다. 같이 떼진 스티커는 제외하고 뗀 스티커의 가중치의 합 중
    가장 큰 값을 구하라

<br>

## 논리적 흐름
    2차원 배열에서 왼쪽을 기준으로 오른쪽으로 한 칸씩 이동하면서 각 칸의 최대값을 구하면서 끝까지 진행

<br>


## 성능
    메모리: 116988KB, 시간: 884ms

<br>

# 2293 동전 1
## 문제 설명
    입력 받은 동전으로 입력 받은 값을 만드는 가짓수를 구하는 문제

<br>

## 논리적 흐름
    짧은 시간 제한 속에 모든 경우의 수를 일일이 구하기 쉽지 않기 때문에 DP를 생각했고,
    원하는 값 이전의 연산이 반복되는 상황이므로 이전의 결과값을 누적합하여 구현해야겠다고 생각함

<br>


## 성능
    메모리: 17752KB, 시간: 220ms